### PR TITLE
fix: skip git hook install when git missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "email:dev": "email dev --dir=src/emails",
-    "postinstall": "npx simple-git-hooks"
+    "postinstall": "node scripts/setup-hooks.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/scripts/setup-hooks.js
+++ b/scripts/setup-hooks.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { execSync } = require('node:child_process');
+
+try {
+    execSync('git --version', { stdio: 'ignore' });
+    execSync('npx simple-git-hooks', { stdio: 'inherit' });
+} catch {
+    console.log('Git not found, skipping git hooks installation');
+}


### PR DESCRIPTION
## Summary
- avoid failing postinstall when `git` is absent
- run git hook setup via custom script

## Testing
- `pnpm lint` *(fails: prettier errors in existing files)*
- `node scripts/setup-hooks.js`


------
https://chatgpt.com/codex/tasks/task_e_68aff7b9b7908323b5a471fe0f6cf4c5