### PR TITLE
Copy hook setup script before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM node:20-bookworm-slim AS deps
 
 WORKDIR /tmp
 
-COPY package.json ./
+COPY package.json pnpm-lock.yaml ./
+COPY scripts/setup-hooks.js ./scripts/setup-hooks.js
 
 # Build
 FROM node:20-bookworm-slim AS builder
@@ -15,7 +16,6 @@ ENV SKIP_ENV_VALIDATION=true
 WORKDIR /app
 
 COPY --from=deps /tmp ./
-COPY pnpm-lock.yaml ./
 
 RUN npm install -g pnpm \
     && pnpm install

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "email:dev": "email dev --dir=src/emails",
-    "postinstall": "npx simple-git-hooks"
+    "postinstall": "node scripts/setup-hooks.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/scripts/setup-hooks.js
+++ b/scripts/setup-hooks.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { execSync } = require('node:child_process');
+
+try {
+    execSync('git --version', { stdio: 'ignore' });
+    execSync('npx simple-git-hooks', { stdio: 'inherit' });
+} catch {
+    console.log('Git not found, skipping git hooks installation');
+}


### PR DESCRIPTION
## Summary
- copy `scripts/setup-hooks.js` into the Docker build context before running `pnpm install`

## Testing
- `pnpm install`
- `node scripts/setup-hooks.js`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff7b9b7908323b5a471fe0f6cf4c5