### PR TITLE
Skip git hooks during Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-bookworm-slim AS deps
 
 WORKDIR /tmp
 
-COPY package.json ./
+COPY package.json pnpm-lock.yaml ./
 
 # Build
 FROM node:20-bookworm-slim AS builder
@@ -15,10 +15,9 @@ ENV SKIP_ENV_VALIDATION=true
 WORKDIR /app
 
 COPY --from=deps /tmp ./
-COPY pnpm-lock.yaml ./
 
 RUN npm install -g pnpm \
-    && pnpm install
+    && pnpm install --ignore-scripts
 
 COPY . .
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y sqlite3
 COPY package.json pnpm-lock.yaml drizzle.config.ts ./
 COPY src/db/schema.ts src/db/schema.ts
 
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm && pnpm install --ignore-scripts
 
 EXPOSE $PORT
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "email:dev": "email dev --dir=src/emails",
-    "postinstall": "npx simple-git-hooks"
+    "postinstall": "node scripts/setup-hooks.js"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.4",

--- a/scripts/setup-hooks.js
+++ b/scripts/setup-hooks.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+const { execSync } = require('node:child_process');
+
+try {
+    execSync('git --version', { stdio: 'ignore' });
+    execSync('npx simple-git-hooks', { stdio: 'inherit' });
+} catch {
+    console.log('Git not found, skipping git hooks installation');
+}


### PR DESCRIPTION
## Summary
- run `pnpm install --ignore-scripts` in Docker builds to bypass git hook setup

## Testing
- `pnpm install`
- `node scripts/setup-hooks.js`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68aff7b9b7908323b5a471fe0f6cf4c5