### PR TITLE
Use pnpm install --ignore-scripts in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY --from=deps /tmp ./
 COPY pnpm-lock.yaml ./
 
 RUN npm install -g pnpm \
-    && pnpm install
+    && pnpm install --ignore-scripts
 
 COPY . .
 

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y sqlite3
 COPY package.json pnpm-lock.yaml drizzle.config.ts ./
 COPY src/db/schema.ts src/db/schema.ts
 
-RUN npm install -g pnpm && pnpm install
+RUN npm install -g pnpm && pnpm install --ignore-scripts
 
 EXPOSE $PORT
 


### PR DESCRIPTION
## Summary
- update both Dockerfiles to install dependencies with `pnpm install --ignore-scripts`
- ensure Docker builds skip git hooks during dependency installation

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d61d9faa888323b93f815c5fa08152